### PR TITLE
Added DO capabilities to visualizer

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,10 +1,10 @@
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install -y wget sudo curl
+RUN apt-get update && apt-get install -y wget sudo curl vim
 RUN wget https://github.com/EOSIO/eosio.cdt/releases/download/v1.6.1/eosio.cdt_1.6.1-1_amd64.deb
 RUN apt-get update && sudo apt install -y ./eosio.cdt_1.6.1-1_amd64.deb
-RUN wget https://github.com/eosio/eos/releases/download/v1.8.1/eosio_1.8.1-1-ubuntu-18.04_amd64.deb
-RUN apt-get update && sudo apt install -y ./eosio_1.8.1-1-ubuntu-18.04_amd64.deb
+RUN wget https://github.com/eosio/eos/releases/download/v2.0.2/eosio_2.0.2-1-ubuntu-18.04_amd64.deb
+RUN apt-get update && sudo apt install -y ./eosio_2.0.2-1-ubuntu-18.04_amd64.deb
 
 RUN apt-get update \
   && apt-get install -y python3-pip python3-dev \
@@ -36,7 +36,6 @@ RUN pip3 install --upgrade pip && \
   pip3 install pebble && \
   pip3 install pickle-mixin && \
   pip3 install pycrypto && \
-  pip3 install "tensorflow==1.14.0" && \
   pip3 install timeloop && \
   pip3 install zipfile36
 
@@ -48,3 +47,6 @@ WORKDIR /bittensor
 
 # Install Bittensor
 RUN pip3 install -e .
+
+RUN pip3 uninstall -y tb-nightly tensorboard tensorflow tensorflow-estimator tf-estimator-nightly
+RUN pip3 install "tensorflow==1.15.2" 

--- a/bittensor/proto/bittensor_pb2.py
+++ b/bittensor/proto/bittensor_pb2.py
@@ -246,32 +246,32 @@ DESCRIPTOR.message_types_by_name['GradeRequest'] = _GRADEREQUEST
 DESCRIPTOR.message_types_by_name['GradeResponse'] = _GRADERESPONSE
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
-SpikeRequest = _reflection.GeneratedProtocolMessageType('SpikeRequest', (_message.Message,), dict(
-  DESCRIPTOR = _SPIKEREQUEST,
-  __module__ = 'bittensor.proto.bittensor_pb2'
+SpikeRequest = _reflection.GeneratedProtocolMessageType('SpikeRequest', (_message.Message,), {
+  'DESCRIPTOR' : _SPIKEREQUEST,
+  '__module__' : 'bittensor.proto.bittensor_pb2'
   # @@protoc_insertion_point(class_scope:SpikeRequest)
-  ))
+  })
 _sym_db.RegisterMessage(SpikeRequest)
 
-SpikeResponse = _reflection.GeneratedProtocolMessageType('SpikeResponse', (_message.Message,), dict(
-  DESCRIPTOR = _SPIKERESPONSE,
-  __module__ = 'bittensor.proto.bittensor_pb2'
+SpikeResponse = _reflection.GeneratedProtocolMessageType('SpikeResponse', (_message.Message,), {
+  'DESCRIPTOR' : _SPIKERESPONSE,
+  '__module__' : 'bittensor.proto.bittensor_pb2'
   # @@protoc_insertion_point(class_scope:SpikeResponse)
-  ))
+  })
 _sym_db.RegisterMessage(SpikeResponse)
 
-GradeRequest = _reflection.GeneratedProtocolMessageType('GradeRequest', (_message.Message,), dict(
-  DESCRIPTOR = _GRADEREQUEST,
-  __module__ = 'bittensor.proto.bittensor_pb2'
+GradeRequest = _reflection.GeneratedProtocolMessageType('GradeRequest', (_message.Message,), {
+  'DESCRIPTOR' : _GRADEREQUEST,
+  '__module__' : 'bittensor.proto.bittensor_pb2'
   # @@protoc_insertion_point(class_scope:GradeRequest)
-  ))
+  })
 _sym_db.RegisterMessage(GradeRequest)
 
-GradeResponse = _reflection.GeneratedProtocolMessageType('GradeResponse', (_message.Message,), dict(
-  DESCRIPTOR = _GRADERESPONSE,
-  __module__ = 'bittensor.proto.bittensor_pb2'
+GradeResponse = _reflection.GeneratedProtocolMessageType('GradeResponse', (_message.Message,), {
+  'DESCRIPTOR' : _GRADERESPONSE,
+  '__module__' : 'bittensor.proto.bittensor_pb2'
   # @@protoc_insertion_point(class_scope:GradeResponse)
-  ))
+  })
 _sym_db.RegisterMessage(GradeResponse)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ numpy
 pebble
 pickle-mixin
 pycrypto
-tensorflow==1.4.0
+tensorflow==1.15.2
 tensorflow_hub==0.4.0
 timeloop
 zipfile36

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     install_requires=[
         'argparse', 'grpcio', 'grpcio-tools', 'libeospy', 'loguru',
         'matplotlib', 'miniupnpc', 'networkx', 'numpy', 'pebble',
-        'pickle-mixin', 'pycrypto', 'sklearn', 'tensorflow==1.15.2',
+        'pickle-mixin', 'pycrypto', 'sklearn', 'tensorflow==1.15.0',
         'tensorflow_hub==0.4.0', 'timeloop', 'zipfile36'
     ],  # Optional
 )

--- a/visualizer/main.py
+++ b/visualizer/main.py
@@ -18,7 +18,7 @@ from TBLogger import TBLogger
 
 class NodeStatsListener():
 
-    def __init__(self, config):
+    def __init__(self, config, eos_url):
         # Init configurations and arguments
         self._config = config
 
@@ -33,6 +33,9 @@ class NodeStatsListener():
 
         # Global step counter.
         self._global_step = 0
+        
+        # EOS url
+        self._eos_url = eos_url
 
     def refresh(self):
         logger.info('Refresh')
@@ -92,7 +95,7 @@ class NodeStatsListener():
         )
 
         payload_json = json.dumps(payload)
-        request_url = self._config.eos.url + self._config.eos.get_table_command
+        request_url =  self._eos_url + self._config.eos.get_table_command
         response = requests.post(url=request_url, data=payload_json)
         if response.status_code == HTTPStatus.OK:
             response_json = response.json()
@@ -162,8 +165,8 @@ class NodeStatsListener():
         logger.info('Logging: node {}: step {} gs {} mem {} loss {} scores {}'.format(node_id, response['step'], response['gs'], response['mem'], response['loss'], scores))
 
 
-def main(config):
-    listener = NodeStatsListener(config)
+def main(config, eos_url):
+    listener = NodeStatsListener(config, eos_url)
     try:
         logger.info('Started listener ...')
         while True:
@@ -181,6 +184,12 @@ if __name__ == "__main__":
         type=str,
         help='Path to config file.'
     )
+    parser.add_argument(
+        '--eos_url',
+        default='http://host.docker.internal',
+        type=str,
+        help='EOS chain URL.'
+    )
     args = parser.parse_args()
     config = Config.get_config_from_yaml(args.config_path)
-    main(config)
+    main(config, args.eos_url)

--- a/visualizer/visualizer.sh
+++ b/visualizer/visualizer.sh
@@ -3,17 +3,19 @@ source ./scripts/constant.sh
 
 function print_help () {
   echo "Script for starting Visualization instance."
-  echo "Usage ./start_visualizer.sh [OPTIONS]"
+  echo "Usage ./visualizer.sh [OPTIONS]"
   echo ""
   echo "Options:"
-  echo " -h, --help       Print this help message and exit"
+  echo " -h, --help            Print this help message and exit"
   echo " -c, --config_path     Path to config yaml."
+  echo " -e, --eos_url         EOS chain path"     
 }
 
 config_path='visualizer/config.yaml'
+eos_url='docker.host.internal'
 
 # Read command line args
-while test 6 -gt 0; do
+while test 4 -gt 0; do
   case "$1" in
     -h|--help)
       print_help
@@ -22,6 +24,10 @@ while test 6 -gt 0; do
     -c|--config_path)
       config_path=`echo $2`
       shift
+      shift
+      ;;
+    -e|--eos_url)
+      eos_url=`echo $2`
       shift
       ;;
     *)
@@ -46,7 +52,7 @@ function start_tensorboard() {
 function start_node_listener() {
 
   log "=== start Visualizer ==="
-  COMMAND="python3 visualizer/main.py --config_path=$config_path"
+  COMMAND="python3 visualizer/main.py --config_path=$config_path --eos_url=$eos_url"
   log "Command: $COMMAND"
   eval $COMMAND &
   LISTENERPID=$!


### PR DESCRIPTION
Now we can run the visualizer locally with `./start_visualizer -e EOS_URL`. 

This PR also fixes the issue with the 1.8 chain being deprecated, migrated to 2.0. 

Finally, this also fixes an issue with visualizer code grabbing wrong script variable to run in container